### PR TITLE
Use Core challenge auth policy

### DIFF
--- a/sdk/keyvault/azure-keyvault-secrets/tests/_shared/test_case.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/_shared/test_case.py
@@ -4,7 +4,7 @@
 # ------------------------------------
 import time
 
-from azure.keyvault.secrets._shared import HttpChallengeCache
+import azure.core.pipeline.policies._http_challenge_cache as HttpChallengeCache
 from devtools_testutils import AzureRecordedTestCase
 
 

--- a/sdk/keyvault/azure-keyvault-secrets/tests/_shared/test_case_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/_shared/test_case_async.py
@@ -4,7 +4,7 @@
 # ------------------------------------
 import asyncio
 
-from azure.keyvault.secrets._shared import HttpChallengeCache
+import azure.core.pipeline.policies._http_challenge_cache as HttpChallengeCache
 from devtools_testutils import AzureRecordedTestCase
 
 


### PR DESCRIPTION
Prototype of how Key Vault could incorporate a multitenant auth-supporting authentication policy in Core, as proposed in https://github.com/Azure/azure-sdk-for-python/pull/24019.